### PR TITLE
Disable wrap for dashboard buffer

### DIFF
--- a/autoload/dashboard.vim
+++ b/autoload/dashboard.vim
@@ -47,6 +47,7 @@ function! dashboard#instance(on_vimenter) abort
         \ nolist
         \ nonumber
         \ norelativenumber
+        \ nowrap
         \ nospell
         \ noswapfile
         \ signcolumn=no


### PR DESCRIPTION
This request disable wrap for dashboard buffer, so with a tiny window the elements still remains right.