### PR TITLE
Respect user predefined fzf layout config

### DIFF
--- a/autoload/dashboard/fzf.vim
+++ b/autoload/dashboard/fzf.vim
@@ -26,8 +26,91 @@ function! dashboard#fzf#book_marks() abort
   Marks
 endfunction
 
-fu s:snr() abort
-    return matchstr(expand('<sfile>'), '.*\zs<SNR>\d\+_')
-endfu
+if g:dashboard_fzf_window == 1
+    let $FZF_DEFAULT_OPTS='--layout=reverse'
+    if !exists('g:dashboard_fzf_window_rate')
+      let g:dashboard_fzf_window_rate = 0.9
+    endif
 
-let s:snr = get(s:, 'snr', s:snr())
+    fu s:snr() abort
+        return matchstr(expand('<sfile>'), '.*\zs<SNR>\d\+_')
+    endfu
+
+    let s:snr = get(s:, 'snr', s:snr())
+    let g:fzf_layout = {'window': 'call '..s:snr..'fzf_window(0.9, 0.6, "Comment")'}
+
+    fu s:fzf_window(width, height, border_highlight) abort
+        let width = float2nr(&columns * a:width)
+        let height = float2nr(&lines * a:height)
+        let row = float2nr((&lines - height) / 2)
+        let col = float2nr((&columns - width) / 2)
+        let top = '┌' . repeat('─', width - 2) . '┐'
+        let mid = '│' . repeat(' ', width - 2) . '│'
+        let bot = '└' . repeat('─', width - 2) . '┘'
+        let border = [top] + repeat([mid], height - 2) + [bot]
+        if has('nvim')
+            let frame = s:create_float(a:border_highlight, {
+                \ 'row': row,
+                \ 'col': col,
+                \ 'width': width,
+                \ 'height': height,
+                \ })
+            call nvim_buf_set_lines(frame, 0, -1, v:true, border)
+            call s:create_float('Normal', {
+                \ 'row': row + 1,
+                \ 'col': col + 2,
+                \ 'width': width - 4,
+                \ 'height': height - 2,
+                \ })
+            exe 'au BufWipeout <buffer> bw '..frame
+        else
+            let frame = s:create_popup_window(a:border_highlight, {
+                \ 'line': row,
+                \ 'col': col,
+                \ 'width': width,
+                \ 'height': height,
+                \ 'is_frame': 1,
+                \ })
+            call setbufline(frame, 1, border)
+            call s:create_popup_window('Normal', {
+                \ 'line': row + 1,
+                \ 'col': col + 2,
+                \ 'width': width - 4,
+                \ 'height': height - 2,
+                \ })
+        endif
+    endfu
+
+    fu s:create_float(hl, opts) abort
+        let buf = nvim_create_buf(v:false, v:true)
+        let opts = extend({'relative': 'editor', 'style': 'minimal'}, a:opts)
+        let win = nvim_open_win(buf, v:true, opts)
+        call setwinvar(win, '&winhighlight', 'NormalFloat:'..a:hl)
+        return buf
+    endfu
+
+    fu s:create_popup_window(hl, opts) abort
+        if has_key(a:opts, 'is_frame')
+            let id = popup_create('', #{
+                \ line: a:opts.line,
+                \ col: a:opts.col,
+                \ minwidth: a:opts.width,
+                \ minheight: a:opts.height,
+                \ zindex: 50,
+                \ })
+            call setwinvar(id, '&wincolor', a:hl)
+            exe 'au BufWipeout * ++once call popup_close('..id..')'
+            return winbufnr(id)
+        else
+            let buf = term_start(&shell, #{hidden: 1})
+            call popup_create(buf, #{
+                \ line: a:opts.line,
+                \ col: a:opts.col,
+                \ minwidth: a:opts.width,
+                \ minheight: a:opts.height,
+                \ zindex: 51,
+                \ })
+            exe 'au BufWipeout * ++once bw! '..buf
+        endif
+    endfu
+endif

--- a/autoload/dashboard/fzf.vim
+++ b/autoload/dashboard/fzf.vim
@@ -2,11 +2,6 @@
 " Description: A fancy start screen for Vim.
 " Maintainer:  Glepnir <http://github.com/glepnir>
 "
-let $FZF_DEFAULT_OPTS='--layout=reverse'
-if !exists('g:dashboard_fzf_window_rate')
-  let g:dashboard_fzf_window_rate = 0.9
-endif
-
 function! dashboard#fzf#find_file() abort
   Files
 endfunction
@@ -36,82 +31,3 @@ fu s:snr() abort
 endfu
 
 let s:snr = get(s:, 'snr', s:snr())
-
-if g:dashboard_fzf_window == 1
-    let g:fzf_layout = {'window': 'call '..s:snr..'fzf_window(0.9, 0.6, "Comment")'}
-endif
-
-fu s:fzf_window(width, height, border_highlight) abort
-    let width = float2nr(&columns * a:width)
-    let height = float2nr(&lines * a:height)
-    let row = float2nr((&lines - height) / 2)
-    let col = float2nr((&columns - width) / 2)
-    let top = '┌' . repeat('─', width - 2) . '┐'
-    let mid = '│' . repeat(' ', width - 2) . '│'
-    let bot = '└' . repeat('─', width - 2) . '┘'
-    let border = [top] + repeat([mid], height - 2) + [bot]
-    if has('nvim')
-        let frame = s:create_float(a:border_highlight, {
-            \ 'row': row,
-            \ 'col': col,
-            \ 'width': width,
-            \ 'height': height,
-            \ })
-        call nvim_buf_set_lines(frame, 0, -1, v:true, border)
-        call s:create_float('Normal', {
-            \ 'row': row + 1,
-            \ 'col': col + 2,
-            \ 'width': width - 4,
-            \ 'height': height - 2,
-            \ })
-        exe 'au BufWipeout <buffer> bw '..frame
-    else
-        let frame = s:create_popup_window(a:border_highlight, {
-            \ 'line': row,
-            \ 'col': col,
-            \ 'width': width,
-            \ 'height': height,
-            \ 'is_frame': 1,
-            \ })
-        call setbufline(frame, 1, border)
-        call s:create_popup_window('Normal', {
-            \ 'line': row + 1,
-            \ 'col': col + 2,
-            \ 'width': width - 4,
-            \ 'height': height - 2,
-            \ })
-    endif
-endfu
-
-fu s:create_float(hl, opts) abort
-    let buf = nvim_create_buf(v:false, v:true)
-    let opts = extend({'relative': 'editor', 'style': 'minimal'}, a:opts)
-    let win = nvim_open_win(buf, v:true, opts)
-    call setwinvar(win, '&winhighlight', 'NormalFloat:'..a:hl)
-    return buf
-endfu
-
-fu s:create_popup_window(hl, opts) abort
-    if has_key(a:opts, 'is_frame')
-        let id = popup_create('', #{
-            \ line: a:opts.line,
-            \ col: a:opts.col,
-            \ minwidth: a:opts.width,
-            \ minheight: a:opts.height,
-            \ zindex: 50,
-            \ })
-        call setwinvar(id, '&wincolor', a:hl)
-        exe 'au BufWipeout * ++once call popup_close('..id..')'
-        return winbufnr(id)
-    else
-        let buf = term_start(&shell, #{hidden: 1})
-        call popup_create(buf, #{
-            \ line: a:opts.line,
-            \ col: a:opts.col,
-            \ minwidth: a:opts.width,
-            \ minheight: a:opts.height,
-            \ zindex: 51,
-            \ })
-        exe 'au BufWipeout * ++once bw! '..buf
-    endif
-endfu

--- a/plugin/dashboard.vim
+++ b/plugin/dashboard.vim
@@ -19,7 +19,7 @@ let s:session_path = expand(($XDG_CACHE_HOME ? $XDG_CACHE_HOME : s:home_dir.'/.c
 " Options
 let g:dashboard_version = '0.0.5'
 let g:dashboard_executive = get(g:,'dashboard_default_executive','clap')
-let g:dashboard_fzf_window =get(g:,'dashboard_fzf_float',1)
+let g:dashboard_fzf_window =get(g:,'dashboard_fzf_window',1)
 let g:dashboard_fzf_engine = get(g:,'dashboard_fzf_engine','rg')
 let g:session_directory = get(g:, 'dashboard_session_directory',  s:session_path.'/session')
 let g:session_enable = get(g:,'dashboard_enable_session',1)


### PR DESCRIPTION
This is how my fzf window (triggered with :Files) usually looks like:
![good](https://user-images.githubusercontent.com/54680730/101993522-06300900-3cc4-11eb-91e8-e234aba0a52c.png)

But after installing `dashboard-nvim`, if I trigger fzf through it, for example by pressing enter on `Find file` or `Recently opened files` at the dashboard screen, `dashboard-nvim` overrides my fzf appearance and layout related config to make it look like this:
![bad](https://user-images.githubusercontent.com/54680730/101993633-c74e8300-3cc4-11eb-9c35-35c0a14b7313.png)

I found that very inconvenient. So, I removed these lines from `autoload/dashboard/fzf.vim` to preserve my fzf layout config. I tested this fix out, and it didn't break anything AFAIK.

PS: I think I noticed it checks if `g:dashboard_fzf_window` equals `1` before overriding my config. So, I tried setting it to `0`, but this didn't fix it.