### PR TITLE
Re-add autoload/dashboard/leaderf.vim

### DIFF
--- a/autoload/dashboard/leaderf.vim
+++ b/autoload/dashboard/leaderf.vim
@@ -1,0 +1,20 @@
+function! dashboard#leaderf#find_file() abort
+  Leaderf file
+endfunction
+
+function! dashboard#leaderf#find_history() abort
+  Leaderf mru
+endfunction
+
+function! dashboard#leaderf#change_colorscheme() abort
+  Leaderf colorscheme 
+endfunction
+
+function! dashboard#leaderf#find_word() abort
+  Leaderf rg
+endfunction
+
+function! dashboard#leaderf#book_marks() abort
+  Leaderf marks
+endfunction
+


### PR DESCRIPTION
I noticed that support for *leaderf* was added after the [commit](https://github.com/glepnir/dashboard-nvim/pull/3/files#diff-e79479952b5415f00ae36be4fdfc66480cec50eca2426194d1b834ba0ece08d2), But  some files about Leaderf have been deleted in the latest commit. 
The commit just re-adds the deleted file. 