### PR TITLE
fix: #49 and neovim-qt issue as mentioned in #11

### DIFF
--- a/plugin/dashboard.vim
+++ b/plugin/dashboard.vim
@@ -39,6 +39,8 @@ augroup dashboard
   autocmd BufReadPost * call dashboard#change_to_dir(expand("%:p"))
   autocmd BufEnter * call dashboard#close_win()
   autocmd User TelescopeFindPre call dashboard#close_win()
+
+  autocmd VimResized * if &filetype ==# 'dashboard' | call dashboard#instance(0) | endif
 augroup END
 
 function! s:loaded_dashboard() abort


### PR DESCRIPTION
This PR adds an `VimResized` autocmd to redraw dashboard when the window is resized, which fixes #49 and the [centering issue](https://github.com/glepnir/dashboard-nvim/issues/11#issuecomment-718596775) mentioned in #11. On neovim-qt, `dashboard#instance(0)` will be called multiple times on startup (4 times in my case), but after that it will be called once per `VimResized`.