### PR TITLE
Center in vertical splits

### DIFF
--- a/autoload/dashboard/utils.vim
+++ b/autoload/dashboard/utils.vim
@@ -3,7 +3,7 @@
 function! dashboard#utils#draw_center(lines) abort
   let longest_line   = max(map(copy(a:lines), 'strwidth(v:val)'))
   let centered_lines = map(copy(a:lines),
-        \ 'repeat(" ", (&columns / 2) - (longest_line / 2)) . v:val')
+        \ 'repeat(" ", (winwidth(0) / 2) - (longest_line / 2)) . v:val')
   return centered_lines
 endfunction
 


### PR DESCRIPTION
Allows the dashboard to be centered within vertical splits, and will automatically realign when the vim window is resized (on the VimResize event).

Couldn't figure out a way to get it to automatically realign when the splits are resized, as their doesn't seem to be an event for that.