### PR TITLE
fix: SessionSave, SessionLoad

### DIFF
--- a/autoload/sessions/session.vim
+++ b/autoload/sessions/session.vim
@@ -2,55 +2,76 @@
 " Description: A fancy start screen for Vim.
 " Maintainer:  Glepnir <http://github.com/glepnir>
 
+let s:separator = has('win32') ? '\' : '/'
+
 function! sessions#session#session_save(name)
   if ! isdirectory(g:session_directory)
     call mkdir(g:session_directory, 'p')
   endif
   let file_name = empty(a:name) ? s:project_name() : a:name
-  let file_path = g:session_directory.'/'.file_name.'.vim'
-  execute 'mksession! '.fnameescape(file_path)
+  let file_path = g:session_directory . s:separator . file_name . '.vim'
+  execute 'mksession! ' . fnameescape(file_path)
   let v:this_session = file_path
 
   echohl MoreMsg
-  echo 'Session `'.file_name.'` is now persistent'
+  echo 'Session `' . file_name . '` is now persistent'
   echohl None
 endfunction
 
 function! sessions#session#session_load(name)
-  let file_name = empty(a:name) ? s:project_name() : a:name
-  let file_path = g:session_directory.'/'.file_name.'.vim'
+  let file_name = empty(a:name) ? s:previous_session_name() : a:name
+  let file_path = g:session_directory . s:separator . file_name . '.vim'
 
   if ! empty(v:this_session) && ! exists('g:SessionLoad')
-    \ |   execute 'mksession! '.fnameescape(v:this_session)
+    \ |   execute 'mksession! ' . fnameescape(v:this_session)
     \ | endif
 
   if filereadable(file_path)
     noautocmd silent! %bwipeout!
-    execute 'silent! source '.file_path
+    execute 'silent! source ' . file_path
     if &laststatus == 0
       set laststatus=2
     endif
-    echomsg 'Loaded "'.file_path.'" session'
+    echomsg 'Loaded "' . file_path . '" session'
   else
     echohl ErrorMsg
-    echomsg 'The session "'.file_path.'" doesn''t exist'
+    echomsg 'The session "' . file_path . '" doesn''t exist'
     echohl None
   endif
 endfunction
 
 function! sessions#session#session_list(A, C, P)
   return map(
-    \ split(glob(g:session_directory.'/*.vim'), '\n'),
+    \ split(glob(g:session_directory . s:separator . '*.vim'), '\n'),
     \ "fnamemodify(v:val, ':t:r')"
     \ )
 endfunction
 
+function! s:sort_by_mtime(foo, bar)
+  let foo = getftime(a:foo)
+  let bar = getftime(a:bar)
+  return foo == bar ? 0 : (foo < bar ? 1 : -1)
+endfunction
+
 function! s:project_name()
-  let l:cwd = resolve(getcwd())
-  let l:cwd = substitute(l:cwd, '^'.$HOME.'/', '', '')
-  let l:cwd = fnamemodify(l:cwd, ':p:gs?/?_?')
-  let l:cwd = substitute(l:cwd, '^\.', '', '')
+  if !has("win32")
+    let l:cwd = resolve(getcwd())
+    let l:cwd = substitute(l:cwd, '^' . $HOME . s:separator, '', '')
+    let l:cwd = fnamemodify(l:cwd, ':p:gs?/?_?')
+    let l:cwd = substitute(l:cwd, '^\ . ', '', '')
+  else
+    let l:cwd = expand("%:t:r")
+  endif
   return l:cwd
+endfunction
+
+function! s:previous_session_name()
+  let l:sessions = globpath(g:session_directory, '*.vim', 0, 1)
+  if len(l:sessions)
+    call sort(l:sessions, 's:sort_by_mtime')
+    let l:session = fnamemodify(l:sessions[0], ':t:r')
+    return l:session
+  endif
 endfunction
 
 

--- a/plugin/dashboard.vim
+++ b/plugin/dashboard.vim
@@ -2,6 +2,8 @@
 " Description: A fancy start screen for Vim.
 " Maintainer:  Glepnir <http://github.com/glepnir>
 
+let s:separator = has('win32') ? '\' : '/'
+
 if exists('g:loaded_dashboard') || &cp
   finish
 endif
@@ -14,14 +16,14 @@ if !get(g:, 'dashboard_disable_at_vimenter') && (!has('nvim') || has('nvim-0.3.5
 endif
 
 let s:home_dir = getenv('HOME')
-let s:session_path = expand(($XDG_CACHE_HOME ? $XDG_CACHE_HOME : s:home_dir.'/.cache') . '/vim')
+let s:session_path = expand(($XDG_CACHE_HOME ? $XDG_CACHE_HOME : s:home_dir . s:separator . '.cache') . s:separator . 'vim')
 
 " Options
 let g:dashboard_version = '0.0.5'
 let g:dashboard_executive = get(g:,'dashboard_default_executive','clap')
 let g:dashboard_fzf_window =get(g:,'dashboard_fzf_window',1)
 let g:dashboard_fzf_engine = get(g:,'dashboard_fzf_engine','rg')
-let g:session_directory = get(g:, 'dashboard_session_directory',  s:session_path.'/session')
+let g:session_directory = get(g:, 'dashboard_session_directory',  s:session_path . s:separator . 'session')
 let g:session_enable = get(g:,'dashboard_enable_session',1)
 let g:dashboard_command = get(g:,'dashboard_preview_command','')
 let g:preview_file_path = get(g:,'dashboard_preview_file','')


### PR DESCRIPTION
potential fix for issue #42 (windows specific fixes).
1. Proper path separators for windows and linux.
2. SessionSave without argument will save a session with current buffer name.
3. SessionLoad without argument loads most recent session sorted by time.