### PR TITLE
fix packer path for footer loader

### DIFF
--- a/autoload/dashboard.vim
+++ b/autoload/dashboard.vim
@@ -124,7 +124,7 @@ function! dashboard#instance(on_vimenter) abort
 endfunction
 
 function! s:print_plugins_message() abort
-  let l:packer = stdpath('data') .'/site/pack/packer/opt/packer.nvim'
+  let l:packer = stdpath('data') .'/site/pack/packer/start/packer.nvim'
   let s:footer_icon = ''
   if exists('g:dashboard_footer_icon')
     let s:footer_icon = get(g:,'dashboard_footer_icon','')


### PR DESCRIPTION
Hi @glepnir 

I would like to create a PR to fix packer path in `dashboard.vim`

According to packer's [README.md](https://github.com/wbthomason/packer.nvim#quickstart)

The installed path should be `~/.local/share/nvim/site/pack/packer/start/packer.nvim`

Thanks!

Alex