### PR TITLE
[Fix up] fix an error caused by detecting the Packer.nvim

### DIFF
--- a/autoload/dashboard.vim
+++ b/autoload/dashboard.vim
@@ -128,7 +128,6 @@ function! dashboard#instance(on_vimenter) abort
 endfunction
 
 function! s:print_plugins_message() abort
-  let l:packer = stdpath('data') .'/site/pack/packer/start/packer.nvim'
   let s:footer_icon = ''
   if exists('g:dashboard_footer_icon')
     let s:footer_icon = get(g:,'dashboard_footer_icon','')
@@ -136,8 +135,10 @@ function! s:print_plugins_message() abort
 
   if has('nvim')
     let l:vim = 'neovim'
+    let l:packer = stdpath('data') .'/site/pack/packer/start/packer.nvim'
   else
     let l:vim = 'vim'
+    let l:packer = ''
   endif
 
   if exists('*dein#get')


### PR DESCRIPTION
Packer.nvim is written by lua so that it cannot be used in vim now. And only neovim has the function stdpath. We need block the operation that detect Packer.nvim in vim.