### PR TITLE
Restore showtabline after leaving dashboard

### DIFF
--- a/plugin/dashboard.lua
+++ b/plugin/dashboard.lua
@@ -50,11 +50,11 @@ api.nvim_create_autocmd('BufReadPost',{
   callback  = function()
     if vim.bo.filetype == 'dashboard' then return end
     if vim.opt.laststatus:get() == 0 then
-      vim.opt.laststatus =2
+      vim.opt.laststatus = 2
     end
 
     if vim.opt.showtabline:get() == 0 then
-      vim.opt.laststatus =2
+      vim.opt.showtabline = 2
     end
   end
 })


### PR DESCRIPTION
Most likely a copy-paste mistake during the rewrite.

The problem here is that I'm not sure what to "restore" it to. I actually use `1` myself, and it's the default in Neovim AFAIK, but I decided not to change the number used here.

Perhaps we should store the value used before Dashboard in a variable and restore that value back afterwards.

Another way is to just not change this setting at all:

1. By default it should be `1`, which hides it when only one tab is open.
2. If Dashboard opens at boot, you don't see it anyway.
3. If user changes it to `2` manually, then they probably *want* to see the tabbar even on the dashboard on start.
4. Opening a new tab and manually opening the dashboard on that tab probably shouldn't hide the tabbar.