### PR TITLE
ADD exit_key, FIX: README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,11 @@ db.custom_center  -- table type and in this table you can set icon,desc,shortcut
                   -- action type can be string or function or nil.
                   -- if you don't need any one of icon shortcut action ,you can ignore it.
 db.custom_footer  -- type can be nil,table or function(must be return table in function)
+db.custom_key           -- table type key that set custom keymap for dashboard
 db.preview_file_Path    -- string or function type that mean in function you can dynamic generate height width
 db.preview_file_height  -- number type
 db.preview_file_width   -- number type
 db.preview_command      -- string type (can be ueberzug which only work in linux)
-db.confirm_key          -- string type key that do confirm in center select
-db.exit_key             -- string type key that exit the dashboard
-db.custom_key           -- table type key that set custom keymap for dashboard
 db.hide_statusline      -- boolean default is true.it will hide statusline in dashboard buffer and auto open in other buffer
 db.hide_tabline         -- boolean default is true.it will hide tabline in dashboard buffer and auto open in other buffer
 db.session_directory    -- string type the directory to store the session file
@@ -167,10 +165,12 @@ You can use `custom_key` to map your custom keymaps for dashboard. For example:
 ```lua
 local db = require "dashboard"
 db.custom_key = {
-    ['1'] = ':Telescope oldfiles<CR>',
-    ['2'] = ':Telescope find_files<CR>',
-    ['3'] = ':Telescope live_grep<CR>',
-    ['4'] = ':edit $MYVIMRC<CR>',
+    ['<Leader>a'] = ':Telescope oldfiles<CR>',
+    ['<Leader>s'] = ':Telescope find_files<CR>',
+    ['<Leader>d'] = ':Telescope live_grep<CR>',
+    ['<Leader>f'] = ':edit $MYVIMRC<CR>',
+    ['<ESC>'] = '<CMD>q!<CR>',
+    ['l'] = '<cmd>lua require "dashboard".call_line_action()<CR>',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ db.preview_file_width   -- number type
 db.preview_command      -- string type (can be ueberzug which only work in linux)
 db.confirm_key          -- string type key that do confirm in center select
 db.exit_key             -- string type key that exit the dashboard
+db.custom_key           -- table type key that set custom keymap for dashboard
 db.hide_statusline      -- boolean default is true.it will hide statusline in dashboard buffer and auto open in other buffer
 db.hide_tabline         -- boolean default is true.it will hide tabline in dashboard buffer and auto open in other buffer
 db.session_directory    -- string type the directory to store the session file
@@ -156,6 +157,20 @@ use {
     require("indent_blankline").setup { filetype_exclude = { "dashboard" }
     }
   end
+}
+```
+
+3. How to custom keymaps in dashboard?
+
+You can use `custom_key` to map your custom keymaps for dashboard. For example:
+
+```lua
+local db = require "dashboard"
+db.custom_key = {
+    ['1'] = ':Telescope oldfiles<CR>',
+    ['2'] = ':Telescope find_files<CR>',
+    ['3'] = ':Telescope live_grep<CR>',
+    ['4'] = ':edit $MYVIMRC<CR>',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ db.preview_file_Path    -- string or function type that mean in function you can
 db.preview_file_height  -- number type
 db.preview_file_width   -- number type
 db.preview_command      -- string type (can be ueberzug which only work in linux)
-db.confirm_kye          -- string type key that do confirm in center select
+db.confirm_key          -- string type key that do confirm in center select
+db.exit_key             -- string type key that exit the dashboard
 db.hide_statusline      -- boolean default is true.it will hide statusline in dashboard buffer and auto open in other buffer
 db.hide_tabline         -- boolean default is true.it will hide tabline in dashboard buffer and auto open in other buffer
 db.session_directory    -- string type the directory to store the session file

--- a/lua/dashboard/init.lua
+++ b/lua/dashboard/init.lua
@@ -374,9 +374,7 @@ local set_keymap = function(bufnr)
     ['l'] = '',
     ['w'] = '',
     ['b'] = '',
-    ['<Bs>'] = '',
-    [db.confirm_key] = '<cmd>lua require("dashboard").call_line_action()<CR>',
-    [db.exit_key] = '<cmd>q!<CR>',
+    ['<BS>'] = '',
   }
 
   for key, rhs in pairs(keys) do

--- a/lua/dashboard/init.lua
+++ b/lua/dashboard/init.lua
@@ -369,6 +369,7 @@ local set_keymap = function(bufnr)
     ['b'] = '',
     ['<Bs>'] = '',
     [db.confirm_key] = '<cmd>lua require("dashboard").call_line_action()<CR>',
+    [db.exit_key] = '<cmd>q!<CR>',
   }
 
   for key, rhs in pairs(keys) do

--- a/lua/dashboard/init.lua
+++ b/lua/dashboard/init.lua
@@ -360,6 +360,13 @@ end)
 
 db.confirm_key = '<CR>'
 
+local custom_keymap = function(bufnr)
+    local custom_key = db.custom_key
+    for key, rhs in pairs(custom_key) do
+        api.nvim_buf_set_keymap(bufnr, 'n', key, rhs, { noremap = true, silent = true, nowait = true })
+    end
+end
+
 local set_keymap = function(bufnr)
   -- disable h l move
   local keys = {
@@ -375,6 +382,7 @@ local set_keymap = function(bufnr)
   for key, rhs in pairs(keys) do
     api.nvim_buf_set_keymap(bufnr, 'n', key, rhs, { noremap = true, silent = true, nowait = true })
   end
+
 end
 
 local dashboard_loaded = false
@@ -455,6 +463,7 @@ function db.instance(on_vimenter)
   end
 
   set_keymap(bufnr)
+  custom_keymap(bufnr)
 
   api.nvim_create_autocmd('CursorMoved', {
     buffer = bufnr,


### PR DESCRIPTION
NOW WE CAN DEFINE `exit_key` IN SETUP FUNCTION.
ADD: `exit_key` TO EXIT THE DASHBOARD
ADD: `exit_key` DESCRIBE IN `README.md`
FIX: `README.md` typo