### PR TITLE
Fix winbar not reappearing after opening a file 

### DIFF
--- a/lua/dashboard/events.lua
+++ b/lua/dashboard/events.lua
@@ -76,7 +76,7 @@ function au:dashboard_events()
       end
 
       if vim.fn.has('nvim-0.8') == 1 then
-        if vim.opt.winbar == '' then
+        if vim.opt.winbar:get() == '' then
           vim.opt.winbar = db.user_winbar_value
         end
       end

--- a/lua/dashboard/init.lua
+++ b/lua/dashboard/init.lua
@@ -426,7 +426,7 @@ function db.new_file()
   end
 
   if vim.fn.has('nvim-0.8') == 1 then
-    if vim.opt_local.winbar == '' then
+    if vim.opt_local.winbar:get() == '' then
       vim.opt_local.winbar = db.user_winbar_value
     end
   end
@@ -460,7 +460,7 @@ function db:instance(on_vimenter, ...)
   db.user_laststatus_value = vim.opt.laststatus:get()
   db.user_showtabline_value = vim.opt.showtabline:get()
   if vim.fn.has('nvim-0.8') == 1 then
-    db.user_winbar_value = vim.opt.winbar
+    db.user_winbar_value = vim.opt.winbar:get()
   end
 
   set_buf_local_options()


### PR DESCRIPTION
This PR should fix the `winbar` not reappearing after opening a new or existing file via the dashboard menu.