### PR TITLE
hyper: add featues + adjust some padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ config = {
   },
   packages = { enable = true }, -- show how many plugins neovim loaded
   -- limit how many projects list, action when you press key or enter it will run this action.
-  project = { limit = 8, icon = 'your icon', action = 'Telescope find_files cwd=' },
-  mru = { limit = 10, icon = 'your icon' },
+  project = { limit = 8, icon = 'your icon', label = 'your label', action = 'Telescope find_files cwd=' },
+  mru = { limit = 10, icon = 'your icon', label = 'your label' },
   footer = {}, -- footer
 }
 ```

--- a/doc/dashboard.txt
+++ b/doc/dashboard.txt
@@ -116,8 +116,8 @@ when use `hyper` theme the available options in `config` is
       },
       packages = { enable = true }, -- show how many plugins neovim loaded
       -- limit how many projects list, action when you press key or enter it will run this action.
-      project = { limit = 8, icon = 'your icon', action = 'Telescope find_files cwd=' },
-      mru = { limit = 10, icon = 'your icon' },
+      project = { limit = 8, icon = 'your icon', label = 'your label', action = 'Telescope find_files cwd=' },
+      mru = { limit = 10, icon = 'your icon', label = 'your label' },
       footer = {}, -- footer
     }
 <

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -89,6 +89,7 @@ local function project_list(config, callback)
     icon = ' ',
     icon_hl = 'DashboardRecentProjectIcon',
     action = 'Telescope find_files cwd=',
+    label = ' Recent Projects: ',
   }, config.project or {})
 
   local res = {}
@@ -112,7 +113,7 @@ local function project_list(config, callback)
         reverse(res)
       end
       table.insert(res, 1, '')
-      table.insert(res, 2, config.project.icon .. ' Recently Projects: ')
+      table.insert(res, 2, config.project.icon .. config.project.label)
       table.insert(res, '')
       callback(res)
     end)
@@ -124,10 +125,11 @@ local function mru_list(config)
     icon = ' ',
     limit = 10,
     icon_hl = 'DashboardMruIcon',
+    label = ' Most Recent Files: ',
   }, config.mru or {})
 
   local list = {
-    config.mru.icon .. ' Most Recent Files: ',
+    config.mru.icon .. config.mru.label,
   }
 
   local groups = {}

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -67,7 +67,6 @@ local function load_packages(config)
   local lines = {
     '',
     'neovim loaded ' .. utils.get_packages_count() .. ' packages',
-    '',
   }
 
   local first_line = api.nvim_buf_line_count(config.bufnr)
@@ -112,7 +111,8 @@ local function project_list(config, callback)
       else
         reverse(res)
       end
-      table.insert(res, 1, config.project.icon .. ' Recently Projects: ')
+      table.insert(res, 1, '')
+      table.insert(res, 2, config.project.icon .. ' Recently Projects: ')
       table.insert(res, '')
       callback(res)
     end)
@@ -217,7 +217,7 @@ local function gen_center(plist, config)
 
   local hotkey = gen_hotkey(config)
   local start_col = plist[plist_len + 2]:find('[^%s]') - 1
-  for i = 2, plist_len do
+  for i = 3, plist_len do
     api.nvim_buf_add_highlight(
       config.bufnr,
       0,
@@ -246,7 +246,7 @@ local function gen_center(plist, config)
   end
 
   -- initialize the cursor pos
-  api.nvim_win_set_cursor(config.winid, { first_line + 2, start_col + 4 })
+  api.nvim_win_set_cursor(config.winid, { first_line + 3, start_col + 4 })
 
   api.nvim_buf_add_highlight(config.bufnr, 0, 'DashboardMruTitle', first_line + plist_len, 0, -1)
   api.nvim_buf_add_highlight(


### PR DESCRIPTION
before if packages was disabled, project list was right under shortcuts and looked bad. This moves the bottom padding of plugins to the top of project list and makes necassay adjustments to any magic numbers to keep the look unchanged.