### PR TITLE
Fix actions that are a lua function causing an error with doom theme

### DIFF
--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -21,7 +21,6 @@ local function generate_center(config)
            item.action,
           { buffer = config.bufnr, nowait = true, silent = true }
       )
-      { buffer = config.bufnr, nowait = true, silent = true })
     end
   end
   lines = utils.element_align(lines)

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -107,7 +107,7 @@ local function generate_center(config)
     if index and config.center[index].action then
       if type(config.center[index].action) == "string" then
         vim.cmd(config.center[index].action)
-      elseif type(config.center[index].action) == "function" then
+      elseif type(config.center[index].action) == 'function' then
         config.center[index].action()
       else
         print("Error with action, check your config")

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -20,7 +20,7 @@ local function generate_center(config)
            item.key,
            item.action,
           { buffer = config.bufnr, nowait = true, silent = true }
-      )
+        )
     end
   end
   lines = utils.element_align(lines)

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -10,7 +10,7 @@ local function generate_center(config)
   do
     table.insert(lines, item.icon and item.icon .. item.desc or item.desc)
     table.insert(lines, '')
-    if item.key and type(item.action) == "string" then
+    if item.key and type(item.action) == 'string' then
       vim.keymap.set('n', item.key, function()
         vim.cmd(item.action)
       end, { buffer = config.bufnr, nowait = true, silent = true })

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -110,7 +110,7 @@ local function generate_center(config)
       elseif type(config.center[index].action) == 'function' then
         config.center[index].action()
       else
-        print("Error with action, check your config")
+        print('Error with action, check your config')
       end
     end
   end, { buffer = config.bufnr, nowait = true, silent = true })

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -15,7 +15,12 @@ local function generate_center(config)
         vim.cmd(item.action)
       end, { buffer = config.bufnr, nowait = true, silent = true })
     elseif item.key and type(item.action) == "function" then
-      vim.keymap.set('n', item.key, item.action,
+        vim.keymap.set(
+           'n',
+           item.key,
+           item.action,
+          { buffer = config.bufnr, nowait = true, silent = true }
+      )
       { buffer = config.bufnr, nowait = true, silent = true })
     end
   end

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -105,7 +105,7 @@ local function generate_center(config)
     local curline = api.nvim_win_get_cursor(0)[1]
     local index = pos_map[curline - first_line]
     if index and config.center[index].action then
-      if type(config.center[index].action) == "string" then
+      if type(config.center[index].action) == 'string' then
         vim.cmd(config.center[index].action)
       elseif type(config.center[index].action) == 'function' then
         config.center[index].action()

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -10,10 +10,13 @@ local function generate_center(config)
   do
     table.insert(lines, item.icon and item.icon .. item.desc or item.desc)
     table.insert(lines, '')
-    if item.key then
+    if item.key and type(item.action) == "string" then
       vim.keymap.set('n', item.key, function()
         vim.cmd(item.action)
       end, { buffer = config.bufnr, nowait = true, silent = true })
+    elseif item.key and type(item.action) == "function" then
+      vim.keymap.set('n', item.key, item.action,
+      { buffer = config.bufnr, nowait = true, silent = true })
     end
   end
   lines = utils.element_align(lines)
@@ -102,7 +105,13 @@ local function generate_center(config)
     local curline = api.nvim_win_get_cursor(0)[1]
     local index = pos_map[curline - first_line]
     if index and config.center[index].action then
-      vim.cmd(config.center[index].action)
+      if type(config.center[index].action) == "string" then
+        vim.cmd(config.center[index].action)
+      elseif type(config.center[index].action) == "function" then
+        config.center[index].action()
+      else
+        print("Error with action, check your config")
+      end
     end
   end, { buffer = config.bufnr, nowait = true, silent = true })
 end


### PR DESCRIPTION
The doom theme was assuming all `action` entries were a string. Fixes #267
