### PR TITLE
Fix: fix example code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ db.setup({
         keymap = 'SPC f d',
         action = 'lua print(3)'
       },
-    }
+    },
     footer = {}  --your footer
   }
 })


### PR DESCRIPTION
The example config of doom will lead to an error:

```
E5113: Error while calling lua chunk: vim/_init_packages.lua:0: /Path/plugin-config/dashboard.lua:31: '}' expected (to close '{' at line 9) near 'footer'
stack traceback:
        [C]: in function 'error'
        vim/_init_packages.lua: in function <vim/_init_packages.lua:0>
        [C]: in function 'require'
```

This pr will add the missing ','