### PR TITLE
hyper: fix shortcut highlight

### DIFF
--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -28,7 +28,7 @@ local function gen_shortcut(config)
   local line = api.nvim_buf_get_lines(config.bufnr, first_line, -1, false)[1]
   local start = line:find('[^%s]') - 1
   for _, item in pairs(shortcut) do
-    local _end = start + api.nvim_strwidth(item.desc) + 2
+    local _end = start + #item.desc
     if item.key then
       _end = _end + api.nvim_strwidth(item.key) + 2
       keymap.set('n', item.key, function()


### PR DESCRIPTION
When using some Nerd Font like 󰏔(`\udb80\udfd4`), the shortcut highlight not work as expect.

<img width="754" alt="image" src="https://user-images.githubusercontent.com/17806506/216749251-d88f634f-8c3d-4823-8718-0ed18a1db9dd.png">


<img width="773" alt="image" src="https://user-images.githubusercontent.com/17806506/216749205-23bf5e4a-045d-42ae-bb88-79d02a33659f.png">


`nvim --version` output:

```
NVIM v0.8.2
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by brew@Monterey

Features: +acl +iconv +tui
```
