### PR TITLE
Fix: in hyper theme failed to open a file with spaces in its path

### DIFF
--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -177,11 +177,11 @@ local function map_key(config, key, content)
     local text = content or api.nvim_get_current_line()
     local scol = utils.is_win and text:find('%w') or text:find('%p')
     text = text:sub(scol)
-    local tbl = vim.split(text, '%s', { trimempty = true })
-    local path = tbl[#tbl]
+    local path = vim.trim(text)
     path = vim.fs.normalize(path)
     path = vim.loop.fs_realpath(path)
     if vim.fn.isdirectory(path) == 1 then
+      path = vim.fn.fnameescape(path)
       vim.cmd(config.project.action .. path)
     else
       vim.cmd('edit ' .. path)


### PR DESCRIPTION
This PR fixed the bug that in hyper theme it's failed to open a file with spaces in its path.

I tried to open file with spaces in its path in the mru list and failed:
```error
E5108: Error executing lua: .../packer/opt/dashboard-nvim/lua/dashboard/theme/hyper.lua:187: attempt to concatenate local 'path' (a nil value)
stack traceback:                                                                                                                                                                          
        .../packer/opt/dashboard-nvim/lua/dashboard/theme/hyper.lua:187: in function <.../packer/opt/dashboard-nvim/lua/dashboard/theme/hyper.lua:176>
```

So I tried to fix it. It works on my PC (Ubuntu 20.04). Not tested on Windows.