### PR TITLE
surroundings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ config = {
       key = 'shortcut key in dashboard buffer not keymap !!',
       key_hl = 'group',
       action = '',
+      surroundings = '[]' -- this can be either an empty string or a two character string
     },
   },
   footer = {},

--- a/doc/dashboard.txt
+++ b/doc/dashboard.txt
@@ -138,6 +138,7 @@ when use `doom` theme the available options in `config` is
           key = 'shortcut key in dashboard buffer not keymap !!',
           key_hl = 'group',
           action = '',
+	  surroundings = '[]'
         },
       },
       footer = {},

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -94,10 +94,14 @@ local function generate_center(config)
         if config.center[idx].keymap then
           table.insert(virt_tbl, { config.center[idx].keymap, 'DashboardShortCut' })
         end
+
+        local key_content = utils.generate_surrounded_key(config.center[idx].surroundings, config.center[idx].key)
+
         table.insert(
           virt_tbl,
-          { ' [' .. config.center[idx].key .. ']', config.center[idx].key_hl or 'DashboardKey' }
+          { key_content, config.center[idx].key_hl or 'DashboardKey' }
         )
+
         api.nvim_buf_set_extmark(config.bufnr, ns, first_line + i - 1, 0, {
           virt_text_pos = 'eol',
           virt_text = virt_tbl,

--- a/lua/dashboard/utils.lua
+++ b/lua/dashboard/utils.lua
@@ -156,4 +156,21 @@ function utils.get_vcs_root(buf)
   end
 end
 
+function utils.generate_surrounded_key(surroundings, key)
+  if surroundings == nil then
+    return '[' .. key .. ']'
+  end
+
+  if string.len(surroundings) ~= 2 and string.len(surroundings) ~= 0 then
+    print('Invalid `surroundings` property. It must be either an empty string or a two character string.')
+    return '[' .. key .. ']'
+  end
+
+  local surrounding_start = string.sub(surroundings, 1, 1)
+  local surrounding_end = string.sub(surroundings, 2, 2)
+  local key_content = surrounding_start .. key .. surrounding_end
+
+  return key_content
+end
+
 return utils


### PR DESCRIPTION
Hi, I recently updated the plugin (I was using a very old version) and while trying to replicate my old configuration I noticed the center section had `[]` around the keys

Before:
<img width="370" alt="Screenshot 2023-02-23 at 11 06 22 p m" src="https://user-images.githubusercontent.com/53100040/221097072-f2725f35-1299-4eec-b679-33b8f570c420.png">

After:
<img width="324" alt="Screenshot 2023-02-23 at 11 07 10 p m" src="https://user-images.githubusercontent.com/53100040/221097131-c5737956-dabf-413b-929c-525825a7fcc4.png">

I didn't find a way to disable it so I added a `surroundings` option to customize it. I honestly think it would be easier to just remove the [] and let the user put them manually if they want to, but I chose to keep the default behaviour. Let me know what you think :)
