### PR TITLE
Improve the dashboard buffer name and make it customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ theme = 'hyper' --  theme is doom and hyper default is hyper
 disable_move    --  defualt is false disable move keymap for hyper
 shortcut_type   --  shorcut type 'letter' or 'number'
 change_to_vcs_root -- default is false,for open file in hyper mru. it will change to the root of vcs
+buffer_name = 'Dashboard' -- the name of the dashboard's buffer. Visible depending on the nvim config
 config = {},    --  config used for theme
 hide = {
   statusline    -- hide statusline default is true

--- a/doc/dashboard.txt
+++ b/doc/dashboard.txt
@@ -71,6 +71,7 @@ OPTIONS                                      *dashboard-configuration-options*
     disable_move    --  defualt is false disable move keymap for hyper
     shortcut_type   --  shorcut type 'letter' or 'number'
     change_to_vcs_root -- default is false,for open file in hyper mru. it will change to the root of vcs
+    buffer_name = 'Dashboard' -- the name of the dashboard's buffer. Visible depending on the nvim config
     config = {},    --  config used for theme
     hide = {
       statusline    -- hide statusline default is true

--- a/lua/dashboard/init.lua
+++ b/lua/dashboard/init.lua
@@ -37,6 +37,7 @@ local function default_options()
     disable_move = false,
     shortcut_type = 'letter',
     change_to_vcs_root = false,
+    buffer_name = 'Dashboard',
     config = {
       week_header = {
         enable = false,
@@ -192,6 +193,28 @@ function db:get_opts(callback)
   )
 end
 
+local function get_unique_buffer_name(opts)
+  local name2 = string.format(opts.buffer_name, 1)
+
+  if -1 == vim.fn.bufnr(name2) then
+    return name2
+  end
+
+  for i = 2, 9999, 1 do
+    local name2 = string.format(opts.buffer_name, i)
+    if name2 == opts.buffer_name then
+      name2 = opts.buffer_name .. '-' .. i
+    end
+
+    if -1 == vim.fn.bufnr(name2) then
+      return name2
+    end
+  end
+
+  -- if we are here, then it is bad ... but chances of getting here are very low
+  error('Unable to find unique name for the dashboard buffer')
+end
+
 function db:load_theme(opts)
   local config = vim.tbl_extend('force', opts.config, {
     path = cache_path(),
@@ -201,6 +224,8 @@ function db:load_theme(opts)
     shortcut_type = opts.shortcut_type,
     change_to_vcs_root = opts.change_to_vcs_root,
   })
+
+  vim.api.nvim_buf_set_name(self.bufnr, get_unique_buffer_name(opts))
 
   if #opts.preview.command > 0 then
     config = vim.tbl_extend('force', config, self.opts.preview)


### PR DESCRIPTION
Dashboard creates a scratch buffer, named 'Scratch' by default. Not very intuitive.

This does not matter much if status/window/tab lines are hidden, the default behaviour. But may not look nice otherwise.