### PR TITLE
Allowed for `config.center.desc = ''`

### DIFF
--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -108,7 +108,12 @@ local function generate_center(config)
 
   local line = api.nvim_buf_get_lines(config.bufnr, first_line, first_line + 1, false)[1]
   local col = line:find('%w')
-  api.nvim_win_set_cursor(config.winid, { first_line + 1, col - 1 })
+  if col then
+    col = col - 1
+  else
+    col = 0
+  end
+  api.nvim_win_set_cursor(config.winid, { first_line + 1, col })
 
   local bottom = api.nvim_buf_line_count(config.bufnr)
   vim.defer_fn(function()
@@ -125,7 +130,7 @@ local function generate_center(config)
           curline = curline + (before > curline and -1 or 1)
         end
         before = curline
-        api.nvim_win_set_cursor(config.winid, { curline, col - 1 })
+        api.nvim_win_set_cursor(config.winid, { curline, col })
       end,
     })
   end, 0)

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -108,7 +108,7 @@ local function generate_center(config)
 
   local line = api.nvim_buf_get_lines(config.bufnr, first_line, first_line + 1, false)[1]
   local col = line:find('%w')
-  col = col and col - 1 or 0
+  col = col and col - 1 or 9999
   api.nvim_win_set_cursor(config.winid, { first_line + 1, col })
 
   local bottom = api.nvim_buf_line_count(config.bufnr)

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -108,11 +108,7 @@ local function generate_center(config)
 
   local line = api.nvim_buf_get_lines(config.bufnr, first_line, first_line + 1, false)[1]
   local col = line:find('%w')
-  if col then
-    col = col - 1
-  else
-    col = 0
-  end
+  col = col and col - 1 or 0
   api.nvim_win_set_cursor(config.winid, { first_line + 1, col })
 
   local bottom = api.nvim_buf_line_count(config.bufnr)


### PR DESCRIPTION
```lua
  local col = line:find('%w')
  if col then
    col = col - 1
  else
    col = 0
  end
```

Added this change and removed all lines that use `col - 1`.

This made it possible to do this
```lua
      require("dashboard").setup {
        theme = 'doom',
        config = {
          header = opts.header,
          footer = { opts.footer },
          center = {
            {
              desc = '',
            },
          },
        }
      }
```

A small note is that some the cursor is visible and all the way on the left and I can't figure out where to place the cursor. I've been looking for ways to hide the cursor, this should probably be in a separate issue or discussion.